### PR TITLE
Update base Python images and silabs flasher version number

### DIFF
--- a/focalcrest_flasher/build.yaml
+++ b/focalcrest_flasher/build.yaml
@@ -1,9 +1,9 @@
 ---
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.11-alpine3.19
-  amd64: ghcr.io/home-assistant/amd64-base-python:3.11-alpine3.19
-  armhf: ghcr.io/home-assistant/armhf-base-python:3.11-alpine3.19
-  armv7: ghcr.io/home-assistant/armv7-base-python:3.11-alpine3.19
-  i386: ghcr.io/home-assistant/i386-base-python:3.11-alpine3.19
+  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.14-alpine3.23
+  amd64: ghcr.io/home-assistant/amd64-base-python:3.14-alpine3.23
+  armhf: ghcr.io/home-assistant/armhf-base-python:3.14-alpine3.23
+  armv7: ghcr.io/home-assistant/armv7-base-python:3.14-alpine3.23
+  i386: ghcr.io/home-assistant/i386-base-python:3.14-alpine3.23
 args:
-  UNIVERSAL_SILABS_FLASHER: 0.0.19
+  UNIVERSAL_SILABS_FLASHER: 0.1.2


### PR DESCRIPTION
The flasher fails with error in python lib dependency: https://github.com/mixtile-rockchip/MIXTILE_Addons/issues/3